### PR TITLE
Forced pythia decays to 1 micron

### DIFF
--- a/submit/HF_pp200_signal/pass1/rundir/phpythia8_HF_MDC2.cfg
+++ b/submit/HF_pp200_signal/pass1/rundir/phpythia8_HF_MDC2.cfg
@@ -30,7 +30,9 @@ SoftQCD:inelastic = on
 
 ! Cuts
 #PhaseSpace:pTHatMin = 10.0
-
+ParticleDecays:limitCylinder = on
+ParticleDecays:xyMax = 0.001
+ParticleDecays:zMax = 0.001
 
 ColourReconnection:mode = 2
 TimeShower:alphaSvalue = 0.18


### PR DESCRIPTION
This should speed up and improve simulations. I guess the decay will now be handled by our own PHG4Decayer and pythia6