### PR TITLE
use new tracking macros

### DIFF
--- a/submit/JS_pp200_signal/pass3trk_embed_pau/rundir/Fun4All_G4_Pass3Trk.C
+++ b/submit/JS_pp200_signal/pass3trk_embed_pau/rundir/Fun4All_G4_Pass3Trk.C
@@ -17,7 +17,12 @@
 #include <G4_ParticleFlow.C>
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>
-#include <G4_Tracking.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_Reco.C>
+#include <Trkr_Eval.C>
+#include <Trkr_QA.C>
+
 #include <G4_User.C>
 #include <QA.C>
 

--- a/submit/JS_pp200_signal/pass3trk_embed_pau/rundir/G4Setup_sPHENIX.C
+++ b/submit/JS_pp200_signal/pass3trk_embed_pau/rundir/G4Setup_sPHENIX.C
@@ -11,14 +11,11 @@
 #include <G4_HcalIn_ref.C>
 #include <G4_HcalOut_ref.C>
 #include <G4_BeamLine.C>
-#include <G4_Intt.C>
+#include <G4_TrkrSimulation.C>
 #include <G4_Magnet.C>
-#include <G4_Micromegas.C>
-#include <G4_Mvtx.C>
 #include <G4_PSTOF.C>
 #include <G4_Pipe.C>
 #include <G4_PlugDoor.C>
-#include <G4_TPC.C>
 #include <G4_User.C>
 #include <G4_World.C>
 #include <G4_ZDC.C>


### PR DESCRIPTION
@pinkenburg just a reminder that the G4_Tracking macro and G4_<subsystem> macros are obsolete and you should use the new macro scheme. This went unnoticed because the warning in G4_Tracking is only in `Tracking_Init` and this macro only runs the hit processing and not the clustering, so `Tracking_Init()` is never called.