### PR TITLE
fix: run with streaming mode

### DIFF
--- a/submit/pythia8_pp_mb/pass1/rundir/Fun4All_G4_Pass1_pp.C
+++ b/submit/pythia8_pp_mb/pass1/rundir/Fun4All_G4_Pass1_pp.C
@@ -76,7 +76,8 @@ int Fun4All_G4_Pass1_pp(
   //===============
 
 // set pp mode for extended readout
-//  TRACKING::pp_mode = true;
+  TRACKING::pp_mode = true;
+  TRACKING::pp_extended_readout_time = 90000;
   // Enable this is emulating the nominal pp/pA/AA collision vertex distribution
   Input::BEAM_CONFIGURATION = Input::pp_COLLISION; // This is for pp
 


### PR DESCRIPTION
This fixes the pass1 macro to run with streaming mode turned on and some nominal extended readout window so that reconstructed hits are generated in the full 100 mus time window. 