### PR TITLE
new calo macro that create calo_nozero and calo_waveform in the same pass

### DIFF
--- a/submit/JS_pp200_signal/pass3calo_all/rundir/Fun4All_G4_Calo.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/Fun4All_G4_Calo.C
@@ -1,0 +1,381 @@
+#ifndef MACRO_FUN4ALLG4CALO_C
+#define MACRO_FUN4ALLG4CALO_C
+
+#include <GlobalVariables.C>
+
+#include <G4_CEmc_Spacal.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Input.C>
+#include <G4_Production.C>
+#include <G4_TopoClusterReco.C>
+
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+
+#include <fun4allutils/TimerStats.h>
+
+#include <caloreco/CaloGeomMapping.h>
+#include <caloreco/CaloTowerBuilder.h>
+#include <caloreco/CaloTowerCalib.h>
+#include <caloreco/CaloWaveformProcessing.h>
+#include <caloreco/CaloTowerStatus.h>
+
+#include <calowaveformsim/CaloWaveformSim.h>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/PHRandomSeed.h>
+#include <phool/recoConsts.h>
+
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libfun4allutils.so)
+R__LOAD_LIBRARY(libCaloWaveformSim.so)
+R__LOAD_LIBRARY(libcalo_reco.so)
+
+int Fun4All_G4_Calo(
+    const int nEvents = 1,
+    const string &inputFile0 = "/sphenix/lustre01/sphnxpro/mdc2/js_pp200_signal/g4hits/run0015/photonjet10/G4Hits_pythia8_PhotonJet10-0000000015-000000.root",
+    const string &inputFile1 = "pedestal-00046796.root",  
+    const string &outputFile = "DST_CALO_ALL_pythia8_PhotonJet5_2MHz-0000000015-00000.root",
+    const string &outdir = ".",
+    const string &cdbtag = "MDC2_ana.418")
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(1);
+
+  // Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
+  PHRandomSeed::Verbosity(1);
+
+  // just if we set some flags somewhere in this macro
+  recoConsts *rc = recoConsts::instance();
+  // By default every random number generator uses
+  // PHRandomSeed() which reads /dev/urandom to get its seed
+  // if the RANDOMSEED flag is set its value is taken as seed
+  // You can either set this to a random value using PHRandomSeed()
+  // which will make all seeds identical (not sure what the point of
+  // this would be:
+  //  rc->set_IntFlag("RANDOMSEED",PHRandomSeed());
+  // or set it to a fixed value so you can debug your code
+  //  rc->set_IntFlag("RANDOMSEED", 12345);
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", cdbtag);
+  rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+
+  //===============
+  // Input options
+  //===============
+  // verbosity setting (applies to all input managers)
+  Input::VERBOSITY = 1;
+  // First enable the input generators
+  // Either:
+  // read previously generated g4-hits files, in this case it opens a DST and skips
+  // the simulations step completely. The G4Setup macro is only loaded to get information
+  // about the number of layers used for the cell reco code
+  Input::READHITS = true;
+  INPUTREADHITS::filename[0] = inputFile0;
+
+  //-----------------
+  // Initialize the selected Input/Event generation
+  //-----------------
+  // This creates the input generator(s)
+  InputInit();
+
+  // register all input generators with Fun4All
+  InputRegister();
+
+  // register the flag handling
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
+
+  // set up production relatedstuff
+  Enable::PRODUCTION = true;
+
+  //======================
+  // Write the DST
+  //======================
+
+  Enable::DSTOUT = true;
+  Enable::DSTOUT_COMPRESS = false;
+  DstOut::OutputDir = outdir;
+  DstOut::OutputFile = outputFile;
+
+  //======================
+  // What to run
+  //======================
+  // Global options (enabled for all enables subsystems - if implemented)
+  //  Enable::VERBOSITY = 1;
+
+  Enable::CEMC = true;
+  Enable::CEMC_CELL = Enable::CEMC && true;
+  Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
+  Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
+
+  Enable::HCALIN = true;
+  Enable::HCALIN_CELL = Enable::HCALIN && true;
+  Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
+  Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
+  G4HCALIN::tower_emin = 0.;
+
+  Enable::HCALOUT = true;
+  Enable::HCALOUT_CELL = Enable::HCALOUT && true;
+  Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
+  Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
+  G4HCALOUT::tower_emin = 0.;
+
+  //------------------
+  // Detector Reconstruction
+  //------------------
+
+  if (Enable::CEMC_CELL) CEMC_Cells();
+
+  if (Enable::HCALIN_CELL) HCALInner_Cells();
+
+  if (Enable::HCALOUT_CELL) HCALOuter_Cells();
+
+  //-----------------------------
+  // CEMC towering and clustering
+  //-----------------------------
+
+  if (Enable::CEMC_TOWER) CEMC_Towers();
+  if (Enable::CEMC_CLUSTER) CEMC_Clusters();
+
+  //-----------------------------
+  // HCAL towering and clustering
+  //-----------------------------
+
+  if (Enable::HCALIN_TOWER) HCALInner_Towers();
+  if (Enable::HCALIN_CLUSTER) HCALInner_Clusters();
+
+  if (Enable::HCALOUT_TOWER) HCALOuter_Towers();
+  if (Enable::HCALOUT_CLUSTER) HCALOuter_Clusters();
+
+  // if enabled, do topoClustering early, upstream of any possible jet reconstruction
+  if (Enable::TOPOCLUSTER) TopoClusterReco();
+
+  // put waveform stuff here
+  {
+    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim();
+    caloWaveformSim->set_detector_type(CaloTowerDefs::HCALOUT);
+    caloWaveformSim->set_detector("HCALOUT");
+    caloWaveformSim->set_nsamples(12);
+    caloWaveformSim->set_pedestalsamples(12);
+    caloWaveformSim->set_timewidth(0.2);
+    caloWaveformSim->set_peakpos(6);
+    // caloWaveformSim->Verbosity(2);
+    // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+    se->registerSubsystem(caloWaveformSim);
+
+    caloWaveformSim = new CaloWaveformSim();
+    caloWaveformSim->set_detector_type(CaloTowerDefs::HCALIN);
+    caloWaveformSim->set_detector("HCALIN");
+    caloWaveformSim->set_nsamples(12);
+    caloWaveformSim->set_pedestalsamples(12);
+    caloWaveformSim->set_timewidth(0.2);
+    caloWaveformSim->set_peakpos(6);
+    //  caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+    se->registerSubsystem(caloWaveformSim);
+
+    caloWaveformSim = new CaloWaveformSim();
+    caloWaveformSim->set_detector_type(CaloTowerDefs::CEMC);
+    caloWaveformSim->set_detector("CEMC");
+    caloWaveformSim->set_nsamples(12);
+    caloWaveformSim->set_pedestalsamples(12);
+    caloWaveformSim->set_timewidth(0.2);
+    caloWaveformSim->set_peakpos(6);
+    caloWaveformSim->set_calibName("cemc_pi0_twrSlope_v1_default");
+
+    //  caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+
+    caloWaveformSim->get_light_collection_model().load_data_file(
+        string(getenv("CALIBRATIONROOT")) +
+            string("/CEMC/LightCollection/Prototype3Module.xml"),
+        "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
+
+    se->registerSubsystem(caloWaveformSim);
+
+    CaloTowerBuilder *ca2 = new CaloTowerBuilder();
+    ca2->set_detector_type(CaloTowerDefs::HCALOUT);
+    ca2->set_nsamples(12);
+    ca2->set_dataflag(false);
+    ca2->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+    ca2->set_builder_type(CaloTowerDefs::kWaveformTowerv2);
+    // match our current ZS threshold ~7ADC for hcal
+    ca2->set_softwarezerosuppression(true, 7);
+    se->registerSubsystem(ca2);
+
+    ca2 = new CaloTowerBuilder();
+    ca2->set_detector_type(CaloTowerDefs::HCALIN);
+    ca2->set_nsamples(12);
+    ca2->set_dataflag(false);
+    ca2->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+    ca2->set_builder_type(CaloTowerDefs::kWaveformTowerv2);
+    ca2->set_softwarezerosuppression(true, 7);
+    se->registerSubsystem(ca2);
+
+    ca2 = new CaloTowerBuilder();
+    ca2->set_detector_type(CaloTowerDefs::CEMC);
+    ca2->set_nsamples(12);
+    ca2->set_dataflag(false);
+    ca2->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+    ca2->set_builder_type(CaloTowerDefs::kWaveformTowerv2);
+    // match our current ZS threshold ~14ADC for emcal
+    ca2->set_softwarezerosuppression(true, 14);
+    se->registerSubsystem(ca2);
+
+    /////////////////////////////////////////////////////
+    // Set status of towers, Calibrate towers,  Cluster
+    /////////////////////////////////////////////////////
+    std::cout << "status setters" << std::endl;
+    CaloTowerStatus *statusEMC = new CaloTowerStatus("CEMCSTATUS");
+    statusEMC->set_detector_type(CaloTowerDefs::CEMC);
+    statusEMC->set_time_cut(1);
+    se->registerSubsystem(statusEMC);
+
+    CaloTowerStatus *statusHCalIn = new CaloTowerStatus("HCALINSTATUS");
+    statusHCalIn->set_detector_type(CaloTowerDefs::HCALIN);
+    statusHCalIn->set_time_cut(2);
+    se->registerSubsystem(statusHCalIn);
+
+    CaloTowerStatus *statusHCALOUT = new CaloTowerStatus("HCALOUTSTATUS");
+    statusHCALOUT->set_detector_type(CaloTowerDefs::HCALOUT);
+    statusHCALOUT->set_time_cut(2);
+    se->registerSubsystem(statusHCALOUT);
+
+    ////////////////////
+    // Calibrate towers
+    std::cout << "Calibrating EMCal" << std::endl;
+    CaloTowerCalib *calibEMC = new CaloTowerCalib("CEMCCALIB");
+    calibEMC->set_detector_type(CaloTowerDefs::CEMC);
+    calibEMC->set_outputNodePrefix("TOWERINFO_CALIB_");
+    se->registerSubsystem(calibEMC);
+
+    std::cout << "Calibrating OHcal" << std::endl;
+    CaloTowerCalib *calibOHCal = new CaloTowerCalib("HCALOUTCALIB");
+    calibOHCal->set_detector_type(CaloTowerDefs::HCALOUT);
+    calibOHCal->set_outputNodePrefix("TOWERINFO_CALIB_");
+    se->registerSubsystem(calibOHCal);
+
+    std::cout << "Calibrating IHcal" << std::endl;
+    CaloTowerCalib *calibIHCal = new CaloTowerCalib("HCALINCALIB");
+    calibIHCal->set_detector_type(CaloTowerDefs::HCALIN);
+    calibIHCal->set_outputNodePrefix("TOWERINFO_CALIB_");
+    se->registerSubsystem(calibIHCal);
+    //////////////////
+    // Clusters
+    std::cout << "Building clusters" << std::endl;
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("CEMC");
+    ClusterBuilder->set_threshold_energy(0.030);  // for when using basic calibration
+    std::string emc_prof = getenv("CALIBRATIONROOT");
+    emc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    ClusterBuilder->LoadProfile(emc_prof);
+    ClusterBuilder->set_UseTowerInfo(1);  // to use towerinfo objects rather than old RawTower
+    se->registerSubsystem(ClusterBuilder);
+  }
+
+  //--------------
+  // Timing module is last to register
+  //--------------
+  TimerStats *ts = new TimerStats();
+  ts->OutFileName("jobtime.root");
+  se->registerSubsystem(ts);
+
+  //--------------
+  // Set up Input Managers
+  //--------------
+
+  InputManagers();
+
+  Fun4AllInputManager *hitsin = new Fun4AllNoSyncDstInputManager("DST2");
+  hitsin->AddFile(inputFile1);
+  hitsin->Repeat();
+  se->registerInputManager(hitsin);
+
+  if (Enable::PRODUCTION)
+  {
+    Production_CreateOutputDir();
+  }
+
+  if (Enable::DSTOUT)
+  {
+    string FullOutFile = DstOut::OutputFile;
+    Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
+    out->AddNode("Sync");
+    out->AddNode("EventHeader");
+    // Inner Hcal
+    out->AddNode("TOWER_SIM_NZ_HCALIN");
+    out->AddNode("TOWER_RAW_NZ_HCALIN");
+    out->AddNode("TOWER_CALIB_NZ_HCALIN");
+    out->AddNode("TOWERINFO_RAW_NZ_HCALIN");
+    out->AddNode("TOWERINFO_SIM_NZ_HCALIN");
+    out->AddNode("TOWERINFO_CALIB_NZ_HCALIN");
+    out->AddNode("CLUSTER_HCALIN");
+    out->AddNode("CLUSTERINFO_HCALIN");
+    out->AddNode("TOWERINFO_CALIB_HCALIN");
+    out->AddNode("WAVEFORM_HCALIN");
+    out->AddNode("TOWERS_HCALIN");
+
+    // Outer Hcal
+    out->AddNode("TOWER_SIM_NZ_HCALOUT");
+    out->AddNode("TOWER_RAW_NZ_HCALOUT");
+    out->AddNode("TOWER_CALIB_NZ_HCALOUT");
+    out->AddNode("TOWERINFO_RAW_NZ_HCALOUT");
+    out->AddNode("TOWERINFO_SIM_NZ_HCALOUT");
+    out->AddNode("TOWERINFO_CALIB_NZ_HCALOUT");
+    out->AddNode("CLUSTER_HCALOUT");
+    out->AddNode("CLUSTERINFO_HCALOUT");
+    out->AddNode("TOWERINFO_CALIB_HCALOUT");
+    out->AddNode("WAVEFORM_HCALOUT");
+    out->AddNode("TOWERS_HCALOUT");
+
+    // CEmc
+    out->AddNode("TOWER_SIM_NZ_CEMC");
+    out->AddNode("TOWER_RAW_NZ_CEMC");
+    out->AddNode("TOWER_CALIB_NZ_CEMC");
+    out->AddNode("TOWERINFO_RAW_NZ_CEMC");
+    out->AddNode("TOWERINFO_SIM_NZ_CEMC");
+    out->AddNode("TOWERINFO_CALIB_NZ_CEMC");
+    out->AddNode("CLUSTER_CEMC");
+    out->AddNode("CLUSTERINFO_CEMC");
+    out->AddNode("TOWERINFO_CALIB_CEMC");
+    out->AddNode("WAVEFORM_CEMC");
+    out->AddNode("TOWERS_CEMC");
+
+    // leave the topo cluster here in case we run this during pass3
+    out->AddNode("TOPOCLUSTER_ALLCALO");
+    out->AddNode("TOPOCLUSTER_EMCAL");
+    out->AddNode("TOPOCLUSTER_HCAL");
+    se->registerOutputManager(out);
+  }
+  //-----------------
+  // Event processing
+  //-----------------
+  // if we use a negative number of events we go back to the command line here
+  if (nEvents < 0)
+  {
+    return 0;
+  }
+  se->run(nEvents);
+
+  //-----
+  // Exit
+  //-----
+
+  CDBInterface::instance()->Print();  // print used DB files
+  se->End();
+  se->PrintTimer();
+  std::cout << "All done" << std::endl;
+  delete se;
+  if (Enable::PRODUCTION)
+  {
+    Production_MoveOutput();
+  }
+
+  gSystem->Exit(0);
+  return 0;
+}
+#endif

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/Fun4All_G4_Calo.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/Fun4All_G4_Calo.C
@@ -189,12 +189,12 @@ int Fun4All_G4_Calo(
     caloWaveformSim->set_calibName("cemc_pi0_twrSlope_v1_default");
 
     //  caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
-
+    /*
     caloWaveformSim->get_light_collection_model().load_data_file(
         string(getenv("CALIBRATIONROOT")) +
             string("/CEMC/LightCollection/Prototype3Module.xml"),
         "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
-
+    */
     se->registerSubsystem(caloWaveformSim);
 
     CaloTowerBuilder *ca2 = new CaloTowerBuilder();

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_CEmc_Spacal.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_CEmc_Spacal.C
@@ -1,0 +1,389 @@
+#ifndef MACRO_G4CEMCSPACAL_C
+#define MACRO_G4CEMCSPACAL_C
+
+#include <GlobalVariables.C>
+#include <QA.C>
+
+#include <g4detectors/PHG4CylinderCellReco.h>
+#include <g4detectors/PHG4CylinderGeom_Spacalv1.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4FullProjSpacalCellReco.h>
+#include <g4detectors/PHG4SpacalSubsystem.h>
+
+#include <g4calo/RawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4Utils.h>
+
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawClusterPositionCorrection.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+double
+CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings);
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libsimqa_modules.so)
+
+namespace Enable
+{
+  bool CEMC = false;
+  bool CEMC_ABSORBER = false;
+  bool CEMC_OVERLAPCHECK = false;
+  bool CEMC_CELL = false;
+  bool CEMC_TOWER = false;
+  bool CEMC_CLUSTER = false;
+  bool CEMC_EVAL = false;
+  bool CEMC_QA = false;
+  bool CEMC_G4Hit = true;
+  int CEMC_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4CEMC
+{
+  int Min_cemc_layer = 1;
+  int Max_cemc_layer = 1;
+
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
+  //   2D azimuthal projective SPACAL (slow)
+  int Cemc_spacal_configuration = PHG4CylinderGeom_Spacalv1::k2DProjectiveSpacal;
+
+  enum enu_Cemc_clusterizer
+  {
+    kCemcGraphClusterizer,
+
+    kCemcTemplateClusterizer
+  };
+
+  //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+  enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
+  //! graph clusterizer, RawClusterBuilderGraph
+  // enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
+
+}  // namespace G4CEMC
+
+// black hole parameters are set in CEmc function
+// needs a dummy argument to play with current G4Setup_sPHENIX.C
+void CEmcInit(const int i = 0)
+{
+}
+
+//! EMCal main setup macro
+double
+CEmc(PHG4Reco *g4Reco, double radius, const int crossings)
+{
+  return CEmc_2DProjectiveSpacal(/*PHG4Reco**/ g4Reco, /*double*/ radius, /*const int */ crossings);
+}
+
+//! 2D full projective SPACAL
+double
+CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::CEMC_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::CEMC_OVERLAPCHECK;
+
+  double emc_inner_radius = 92;  // emc inner radius from engineering drawing
+  double cemcthickness = 22.50000 - no_overlapp;
+
+  // max radius is 116 cm;
+  double emc_outer_radius = emc_inner_radius + cemcthickness;  // outer radius
+  assert(emc_outer_radius < 116);
+
+  if (radius > emc_inner_radius)
+  {
+    cout << "inconsistency: preshower radius+thickness: " << radius
+         << " larger than emc inner radius: " << emc_inner_radius << endl;
+    gSystem->Exit(-1);
+  }
+
+  // the radii are only to determined the thickness of the cemc
+  radius = emc_inner_radius;
+
+  // 1.5cm thick teflon as an approximation for EMCAl light collection + electronics (10% X0 total estimated)
+  PHG4CylinderSubsystem *cyl = new PHG4CylinderSubsystem("CEMC_ELECTRONICS", 0);
+  cyl->set_double_param("radius", radius);
+  cyl->set_string_param("material", "G4_TEFLON");
+  cyl->set_double_param("thickness", 1.5 - no_overlapp);
+  cyl->SuperDetector("CEMC_ELECTRONICS");
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  radius += 1.5;
+  cemcthickness -= 1.5 + no_overlapp;
+
+  // 0.5cm thick Stainless Steel as an approximation for EMCAl support system
+  cyl = new PHG4CylinderSubsystem("CEMC_SPT", 0);
+  cyl->SuperDetector("CEMC_SPT");
+  cyl->set_double_param("radius", radius + cemcthickness - 0.5);
+  cyl->set_string_param("material", "SS310");  // SS310 Stainless Steel
+  cyl->set_double_param("thickness", 0.5 - no_overlapp);
+  cyl->OverlapCheck(OverlapCheck);
+  if (AbsorberActive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  // this is the z extend and outer radius of the support structure and therefore the z extend
+  // and radius of the surrounding black holes
+  double sptlen = PHG4Utils::GetLengthForRapidityCoverage(radius + cemcthickness);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, sptlen);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -sptlen);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, radius + cemcthickness);
+
+  cemcthickness -= 0.5 + no_overlapp;
+
+  int ilayer = 0;
+  PHG4SpacalSubsystem *cemc;
+
+  cemc = new PHG4SpacalSubsystem("CEMC", ilayer);
+
+  cemc->set_int_param("virualize_fiber", 0);
+  cemc->set_int_param("azimuthal_seg_visible", 1);
+  cemc->set_int_param("construction_verbose", 0);
+  cemc->Verbosity(0);
+  cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
+  cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2023ProjTilted/"));
+  cemc->set_double_param("radius", radius);            // overwrite minimal radius
+  cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness
+  if(G4CEMC::Cemc_spacal_configuration == PHG4CylinderGeom_Spacalv1::k2DProjectiveSpacal) cemc->set_int_param("saveg4hit", Enable::CEMC_G4Hit);
+
+  cemc->SetActive();
+  cemc->SuperDetector("CEMC");
+  if (AbsorberActive) cemc->SetAbsorberActive();
+  cemc->OverlapCheck(OverlapCheck);
+
+  g4Reco->registerSubsystem(cemc);
+
+  if (ilayer > G4CEMC::Max_cemc_layer)
+  {
+    cout << "layer discrepancy, current layer " << ilayer
+         << " max cemc layer: " << G4CEMC::Max_cemc_layer << endl;
+  }
+
+  radius += cemcthickness;
+  radius += no_overlapp;
+
+  return radius;
+}
+
+void CEMC_Cells()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4CEMC::Cemc_spacal_configuration == PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal)
+  {
+    PHG4CylinderCellReco *cemc_cells = new PHG4CylinderCellReco("CEMCCYLCELLRECO");
+    cemc_cells->Detector("CEMC");
+    cemc_cells->Verbosity(verbosity);
+    for (int i = G4CEMC::Min_cemc_layer; i <= G4CEMC::Max_cemc_layer; i++)
+    {
+      //          cemc_cells->etaphisize(i, 0.024, 0.024);
+      const double radius = 95;
+      cemc_cells->cellsize(i, 2 * M_PI / 256. * radius, 2 * M_PI / 256. * radius);
+    }
+    se->registerSubsystem(cemc_cells);
+  }
+  else if (G4CEMC::Cemc_spacal_configuration == PHG4CylinderGeom_Spacalv1::k2DProjectiveSpacal)
+  {
+    if (!Enable::CEMC_G4Hit) return;
+    PHG4FullProjSpacalCellReco *cemc_cells = new PHG4FullProjSpacalCellReco("CEMCCYLCELLRECO");
+    cemc_cells->Detector("CEMC");
+    cemc_cells->Verbosity(verbosity);
+    cemc_cells->get_light_collection_model().load_data_file(
+        string(getenv("CALIBRATIONROOT")) + string("/CEMC/LightCollection/Prototype3Module.xml"),
+        "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
+    se->registerSubsystem(cemc_cells);
+  }
+  else
+  {
+    cout << "G4_CEmc_Spacal.C::CEmc - Fatal Error - unrecognized SPACAL configuration #"
+         << G4CEMC::Cemc_spacal_configuration << ". Force exiting..." << endl;
+    gSystem->Exit(-1);
+    return;
+  }
+
+  return;
+}
+
+void CEMC_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  if (Enable::CEMC_G4Hit)
+  {
+    RawTowerBuilder *TowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
+    TowerBuilder->Detector("CEMC");
+    TowerBuilder->set_sim_tower_node_prefix("SIM_NZ");
+    TowerBuilder->Verbosity(verbosity);
+    se->registerSubsystem(TowerBuilder);
+  }
+  double sampling_fraction = 1;
+  //      sampling_fraction = 0.02244; //from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.3/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
+  //    sampling_fraction = 2.36081e-02;  //from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
+  //    sampling_fraction = 1.90951e-02; // 2017 Tilt porjective SPACAL, 8 GeV photon, eta = 0.3 - 0.4
+  sampling_fraction = 2e-02;                 // 2017 Tilt porjective SPACAL, tower-by-tower calibration
+  const double photoelectron_per_GeV = 500;  // 500 photon per total GeV deposition
+
+  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
+  TowerDigitizer->Detector("CEMC");
+  TowerDigitizer->set_sim_tower_node_prefix("SIM_NZ");
+  TowerDigitizer->set_raw_tower_node_prefix("RAW_NZ");  
+  TowerDigitizer->Verbosity(verbosity);
+  TowerDigitizer->set_digi_algorithm(G4CEMC::TowerDigi);
+  TowerDigitizer->set_variable_pedestal(true);  // read ped central and width from calibrations file comment next 2 lines if true
+                                                //   TowerDigitizer->set_pedstal_central_ADC(0);
+                                                //   TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  TowerDigitizer->set_photonelec_ADC(1);                // not simulating ADC discretization error
+  TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
+  //TowerDigitizer->set_variable_zero_suppression(true);  // read zs values from calibrations file comment next line if true
+  TowerDigitizer->set_zero_suppression_ADC(-9999);  // eRD1 test beam setting
+  if (!Enable::CEMC_G4Hit) TowerDigitizer->set_towerinfo(RawTowerDigitizer::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  if (Enable::CDB)
+  {
+    TowerDigitizer->GetParameters().ReadFromCDB("EMCTOWERCALIB");
+  }
+  else
+  {
+    TowerDigitizer->GetParameters().ReadFromFile("CEMC", "xml", 0, 0,
+                                                 string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
+  }
+  se->registerSubsystem(TowerDigitizer);
+
+  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("EmcRawTowerCalibration");
+  TowerCalibration->Detector("CEMC");
+  TowerCalibration->set_raw_tower_node_prefix("RAW_NZ");
+  TowerCalibration->set_calib_tower_node_prefix("CALIB_NZ");
+  TowerCalibration->Verbosity(verbosity);
+  if (!Enable::CEMC_G4Hit) TowerCalibration->set_towerinfo(RawTowerCalibration::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  if (G4CEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    // just use sampling fraction set previously
+    TowerCalibration->set_calib_const_GeV_ADC(1.0 / sampling_fraction);
+  }
+  else
+  {
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kTower_by_tower_calibration);
+    if (Enable::CDB)
+    {
+      TowerCalibration->GetCalibrationParameters().ReadFromCDB("EMCTOWERCALIB");
+    }
+    else
+    {
+      TowerCalibration->GetCalibrationParameters().ReadFromFile("CEMC", "xml", 0, 0,
+                                                                string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
+    }
+    TowerCalibration->set_variable_GeV_ADC(true);                                                                                                     // read GeV per ADC from calibrations file comment next line if true
+    //    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
+    //TowerCalibration->set_variable_pedestal(true);  // read pedestals from calibrations file comment next line if true
+    TowerCalibration->set_pedstal_ADC(0);
+  }
+  se->registerSubsystem(TowerCalibration);
+
+  return;
+}
+
+void CEMC_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4CEMC::Cemc_clusterizer == G4CEMC::kCemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("CEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->setInputTowerNodeName("TOWERINFO_CALIB_NZ_CEMC");
+    ClusterBuilder->setOutputClusterNodeName("CLUSTER_CEMC");
+    ClusterBuilder->set_UseTowerInfo(1);
+    ClusterBuilder->set_threshold_energy(0.030);  // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    std::string emc_prof = getenv("CALIBRATIONROOT");
+    emc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    ClusterBuilder->LoadProfile(emc_prof);
+    //    ClusterBuilder->set_UseTowerInfo(1); // to use towerinfo objects rather than old RawTower
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4CEMC::Cemc_clusterizer == G4CEMC::kCemcGraphClusterizer)
+  {
+    RawClusterBuilderGraph *ClusterBuilder = new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
+    ClusterBuilder->Detector("CEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "CEMC_Clusters - unknown clusterizer setting!" << endl;
+    exit(1);
+  }
+
+  RawClusterPositionCorrection *clusterCorrection = new RawClusterPositionCorrection("CEMC");
+  if (!Enable::CEMC_G4Hit) clusterCorrection->set_UseTowerInfo(1);  // just use towerinfo
+  //    clusterCorrection->set_UseTowerInfo(1); // to use towerinfo objects rather than old RawTower
+
+//  if (Enable::CDB)
+//  {
+//    clusterCorrection->Get_eclus_CalibrationParameters().ReadFromCDB("CEMCRECALIB");
+//    clusterCorrection->Get_ecore_CalibrationParameters().ReadFromCDB("CEMC_ECORE_RECALIB");
+//  }
+//  else
+//  {
+//    clusterCorrection->Get_eclus_CalibrationParameters().ReadFromFile("CEMC_RECALIB", "xml", 0, 0,
+//                                                                      // raw location
+//                                                                      string(getenv("CALIBRATIONROOT")) + string("/CEMC/PositionRecalibration_EMCal_9deg_tilt/"));
+//    clusterCorrection->Get_ecore_CalibrationParameters().ReadFromFile("CEMC_ECORE_RECALIB", "xml", 0, 0,
+//                                                                      // raw location
+//                                                                      string(getenv("CALIBRATIONROOT")) + string("/CEMC/PositionRecalibration_EMCal_9deg_tilt/"));
+//  }
+
+  clusterCorrection->Verbosity(verbosity);
+  //se->registerSubsystem(clusterCorrection);
+
+  return;
+}
+void CEMC_Eval(const std::string &outputfile)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("CEMCEVALUATOR", "CEMC", outputfile);
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+
+void CEMC_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("CEMC");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
+#endif

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalIn_ref.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalIn_ref.C
@@ -338,7 +338,9 @@ void HCALInner_Clusters()
     ClusterBuilder->Detector("HCALIN");
     ClusterBuilder->SetCylindricalGeometry();                     // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
-    if (!Enable::HCALIN_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    ClusterBuilder->setInputTowerNodeName("TOWERINFO_CALIB_NZ_HCALIN");
+    ClusterBuilder->setOutputClusterNodeName("CLUSTER_HCALIN");
+    ClusterBuilder->set_UseTowerInfo(1);
     se->registerSubsystem(ClusterBuilder);
   }
   else if (G4HCALIN::HCalIn_clusterizer == G4HCALIN::kHCalInGraphClusterizer)

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalIn_ref.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalIn_ref.C
@@ -1,0 +1,385 @@
+// Inner HCal reconstruction macro
+#ifndef MACRO_G4HCALINREF_C
+#define MACRO_G4HCALINREF_C
+
+#include <GlobalVariables.C>
+#include <QA.C>
+
+#include <g4calo/HcalRawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4ihcal/PHG4IHCalSubsystem.h>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4HcalCellReco.h>
+#include <g4detectors/PHG4InnerHcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4ihcal.so)
+R__LOAD_LIBRARY(libsimqa_modules.so)
+
+
+namespace Enable
+{
+  bool HCALIN = false;
+  bool HCALIN_ABSORBER = false;
+  bool HCALIN_OVERLAPCHECK = false;
+  bool HCALIN_CELL = false;
+  bool HCALIN_TOWER = false;
+  bool HCALIN_CLUSTER = false;
+  bool HCALIN_EVAL = false;
+  bool HCALIN_QA = false;
+  bool HCALIN_SUPPORT = false;
+  bool HCALIN_OLD = false;
+  bool HCALIN_G4Hit = true;
+  int HCALIN_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4HCALIN
+{
+  double inch = 2.54;
+  double support_ring_outer_radius = 177.323;
+  double support_ring_z = 175.375 * inch / 2;
+  double dz = 4. * inch;
+
+  double phistart = NAN;
+  double tower_emin = NAN;
+  int light_scint_model = -1;
+  int tower_energy_source = -1;
+
+  // Inner HCal absorber material selector:
+  // false - old version, absorber material is SS310
+  // true - default Choose if you want Aluminum
+  bool inner_hcal_material_Al = true;
+
+  int inner_hcal_eic = 0;
+
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
+  enum enu_HCalIn_clusterizer
+  {
+    kHCalInGraphClusterizer,
+
+    kHCalInTemplateClusterizer
+  };
+  
+  bool useTowerInfoV2 = false;
+  //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+  enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInTemplateClusterizer;
+  //! graph clusterizer, RawClusterBuilderGraph
+  // enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInGraphClusterizer;
+}  // namespace G4HCALIN
+
+// Init is called by G4Setup.C
+void HCalInnerInit(const int iflag = 0)
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4HCALIN::support_ring_outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4HCALIN::support_ring_z + G4HCALIN::dz / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4HCALIN::support_ring_z - G4HCALIN::dz / 2.);
+  if (iflag == 1)
+  {
+    G4HCALIN::inner_hcal_eic = 1;
+  }
+}
+
+double HCalInner(PHG4Reco *g4Reco,
+                 double radius,
+                 const int crossings)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::HCALIN_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALIN_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
+
+  PHG4DetectorSubsystem *hcal = nullptr;
+  //  Mephi Maps
+  //  Maps are different for old/new but how to set is identical
+  //  here are the ones for the gdml based inner hcal
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
+  //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
+  //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
+
+  // all sizes are in cm!
+  if (Enable::HCALIN_OLD)
+  {
+    hcal = new PHG4InnerHcalSubsystem("HCALIN");
+    // these are the parameters you can change with their default settings
+    // hcal->set_string_param("material","SS310");
+    if (G4HCALIN::inner_hcal_material_Al)
+    {
+      if (verbosity > 0)
+      {
+        cout << "HCalInner - construct inner HCal absorber with G4_Al" << endl;
+      }
+      hcal->set_string_param("material", "G4_Al");
+    }
+    else
+    {
+      if (verbosity > 0)
+      {
+        cout << "HCalInner - construct inner HCal absorber with SS310" << endl;
+      }
+      hcal->set_string_param("material", "SS310");
+    }
+    // hcal->set_double_param("inner_radius", 117.27);
+    //-----------------------------------------
+    // the light correction can be set in a single call
+    // hcal->set_double_param("light_balance_inner_corr", NAN);
+    // hcal->set_double_param("light_balance_inner_radius", NAN);
+    // hcal->set_double_param("light_balance_outer_corr", NAN);
+    // hcal->set_double_param("light_balance_outer_radius", NAN);
+    // hcal->SetLightCorrection(NAN,NAN,NAN,NAN);
+    //-----------------------------------------
+    // hcal->set_double_param("outer_radius", 134.42);
+    // hcal->set_double_param("place_x", 0.);
+    // hcal->set_double_param("place_y", 0.);
+    // hcal->set_double_param("place_z", 0.);
+    // hcal->set_double_param("rot_x", 0.);
+    // hcal->set_double_param("rot_y", 0.);
+    // hcal->set_double_param("rot_z", 0.);
+    // hcal->set_double_param("scinti_eta_coverage", 1.1);
+    // hcal->set_double_param("scinti_gap_neighbor", 0.1);
+    // hcal->set_double_param("scinti_inner_gap", 0.85);
+    // hcal->set_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
+    // hcal->set_double_param("scinti_outer_radius", 133.3);
+    // hcal->set_double_param("scinti_tile_thickness", 0.7);
+    // hcal->set_double_param("size_z", 175.94 * 2);
+    // hcal->set_double_param("steplimits", NAN);
+    // hcal->set_double_param("tilt_angle", 36.15);
+
+    // hcal->set_int_param("light_scint_model", 1);
+    // hcal->set_int_param("ncross", 0);
+    // hcal->set_int_param("n_towers", 64);
+    // hcal->set_int_param("n_scinti_plates_per_tower", 4);
+    // hcal->set_int_param("n_scinti_tiles", 12);
+
+    // hcal->set_string_param("material", "SS310");
+  }
+  else
+  {
+    hcal = new PHG4IHCalSubsystem("HCALIN");
+    // hcal->set_string_param("GDMPath", "mytestgdml.gdml"); // try other gdml file
+  }
+  if (G4HCALIN::light_scint_model >= 0)
+  {
+    hcal->set_int_param("light_scint_model", G4HCALIN::light_scint_model);
+  }
+  hcal->SetActive();
+  hcal->SuperDetector("HCALIN");
+  if (AbsorberActive)
+  {
+    hcal->SetAbsorberActive();
+  }
+  if (!isfinite(G4HCALIN::phistart))
+  {
+    if (Enable::HCALIN_OLD)
+    {
+      G4HCALIN::phistart = 0.0328877688;  // offet in phi (from zero) extracted from geantinos
+    }
+    else
+    {
+      G4HCALIN::phistart = 0.0445549893;  // offet in phi (from zero) extracted from geantinos
+    }
+  }
+  hcal->set_int_param("saveg4hit", Enable::HCALIN_G4Hit);
+  hcal->set_double_param("phistart", G4HCALIN::phistart);
+  hcal->OverlapCheck(OverlapCheck);
+
+  g4Reco->registerSubsystem(hcal);
+
+  radius = hcal->get_double_param("outer_radius");
+
+  // HCalInner_SupportRing(g4Reco);
+
+  radius += no_overlapp;
+  return radius;
+}
+
+void HCALInner_Cells()
+{
+  if (!Enable::HCALIN_G4Hit) return;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4HcalCellReco *hc = new PHG4HcalCellReco("HCALIN_CELLRECO");
+  hc->Detector("HCALIN");
+  hc->Verbosity(verbosity);
+  // check for energy conservation - needs modified "infinite" timing cuts
+  // 0-999999999
+  //  hc->checkenergy();
+  // timing cuts with their default settings
+  // hc->set_double_param("tmin",0.);
+  // hc->set_double_param("tmax",60.0);
+  // or all at once:
+  // hc->set_timing_window(0.0,60.0);
+  // this sets all cells to a fixed energy for debugging
+  // hc->set_fixed_energy(1.);
+  se->registerSubsystem(hc);
+
+  return;
+}
+
+void HCALInner_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+  if (Enable::HCALIN_G4Hit)
+  {
+    HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalInRawTowerBuilder");
+    TowerBuilder->Detector("HCALIN");
+    TowerBuilder->set_sim_tower_node_prefix("SIM_NZ");
+    if (!isfinite(G4HCALIN::phistart))
+    {
+      if (Enable::HCALIN_OLD)
+      {
+        G4HCALIN::phistart = 0.0328877688;  // offet in phi (from zero) extracted from geantinos
+      }
+      else
+      {
+        G4HCALIN::phistart = 0.0445549893;  // offet in phi (from zero) extracted from geantinos
+      }
+    }
+    TowerBuilder->set_double_param("phistart", G4HCALIN::phistart);
+    if (isfinite(G4HCALIN::tower_emin))
+    {
+      TowerBuilder->set_double_param("emin", G4HCALIN::tower_emin);
+    }
+    if (G4HCALIN::tower_energy_source >= 0)
+    {
+      TowerBuilder->set_int_param("tower_energy_source", G4HCALIN::tower_energy_source);
+    }
+    // this sets specific decalibration factors
+    // for a given cell
+    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+    // for a whole tower
+    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+    TowerBuilder->Verbosity(verbosity);
+    se->registerSubsystem(TowerBuilder);
+  }
+  // From 2016 Test beam sim
+  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
+  TowerDigitizer->Detector("HCALIN");
+  TowerDigitizer->set_sim_tower_node_prefix("SIM_NZ");
+  TowerDigitizer->set_raw_tower_node_prefix("RAW_NZ");
+  TowerDigitizer->set_digi_algorithm(G4HCALIN::TowerDigi);
+  TowerDigitizer->set_pedstal_central_ADC(0);
+  TowerDigitizer->set_pedstal_width_ADC(1);  // From Jin's guess. No EMCal High Gain data yet! TODO: update
+  TowerDigitizer->set_photonelec_ADC(32. / 5.);
+  TowerDigitizer->set_photonelec_yield_visible_GeV(32. / 5 / (0.4e-3));
+  TowerDigitizer->set_zero_suppression_ADC(-9999);                 // no-zero suppression
+  TowerDigitizer->Verbosity(verbosity);
+  if (!Enable::HCALIN_G4Hit) TowerDigitizer->set_towerinfo(RawTowerDigitizer::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  se->registerSubsystem(TowerDigitizer);
+
+  // Default sampling fraction for SS310
+  double visible_sample_fraction_HCALIN = 0.0631283;                                //, /gpfs/mnt/gpfs04/sphenix/user/jinhuang/prod_analysis/hadron_shower_res_nightly/./G4Hits_sPHENIX_pi-_eta0_16GeV-0000.root_qa.rootQA_Draw_HCALIN_G4Hit.pdf
+
+  if (G4HCALIN::inner_hcal_material_Al) visible_sample_fraction_HCALIN = 0.162166;  // for "G4_Al", Abhisek Sen <sen.abhisek@gmail.com>
+
+  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
+  TowerCalibration->Detector("HCALIN");
+  TowerCalibration->set_raw_tower_node_prefix("RAW_NZ");
+  TowerCalibration->set_calib_tower_node_prefix("CALIB_NZ");
+  TowerCalibration -> set_usetowerinfo_v2(G4HCALIN::useTowerInfoV2);
+  //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
+  //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
+  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  if (G4HCALIN::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    // 0.176 extracted from electron sims (edep(scintillator)/edep(total))
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.176);
+  }
+  else
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
+  }
+  TowerCalibration->set_pedstal_ADC(0);
+  TowerCalibration->Verbosity(verbosity);
+  if (!Enable::HCALIN_G4Hit) TowerCalibration->set_towerinfo(RawTowerCalibration::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  se->registerSubsystem(TowerCalibration);
+
+  return;
+}
+
+void HCALInner_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4HCALIN::HCalIn_clusterizer == G4HCALIN::kHCalInTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("HCALIN");
+    ClusterBuilder->SetCylindricalGeometry();                     // has to be called after Detector()
+    ClusterBuilder->Verbosity(verbosity);
+    if (!Enable::HCALIN_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4HCALIN::HCalIn_clusterizer == G4HCALIN::kHCalInGraphClusterizer)
+  {
+    RawClusterBuilderGraph *ClusterBuilder = new RawClusterBuilderGraph("HcalInRawClusterBuilderGraph");
+    ClusterBuilder->Detector("HCALIN");
+    ClusterBuilder->Verbosity(verbosity);
+    //if (!Enable::HCALIN_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "HCalIn_Clusters - unknown clusterizer setting!" << endl;
+    exit(1);
+  }
+  return;
+}
+
+void HCALInner_Eval(const std::string &outputfile, int start_event = 0)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("HCALINEVALUATOR", "HCALIN", outputfile);
+  eval->set_event(start_event);
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+
+void HCALInner_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HCALIN_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("HCALIN");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
+#endif

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalOut_ref.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalOut_ref.C
@@ -1,0 +1,419 @@
+#ifndef MACRO_G4HCALOUTREF_C
+#define MACRO_G4HCALOUTREF_C
+
+#include <GlobalVariables.C>
+#include <QA.C>
+
+#include <g4calo/HcalRawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4ohcal/PHG4OHCalSubsystem.h>
+
+#include <g4detectors/PHG4HcalCellReco.h>
+#include <g4detectors/PHG4OuterHcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4ohcal.so)
+R__LOAD_LIBRARY(libsimqa_modules.so)
+
+namespace Enable
+{
+  bool HCALOUT = false;
+  bool HCALOUT_ABSORBER = false;
+  bool HCALOUT_OVERLAPCHECK = false;
+  bool HCALOUT_CELL = false;
+  bool HCALOUT_TOWER = false;
+  bool HCALOUT_CLUSTER = false;
+  bool HCALOUT_EVAL = false;
+  bool HCALOUT_QA = false;
+  bool HCALOUT_OLD = false;
+  bool HCALOUT_RING = true;
+  bool HCALOUT_G4Hit = true;
+  int HCALOUT_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4HCALOUT
+{
+  double outer_radius = 269.317 + 5;
+  double size_z = 639.240 + 10;
+  double phistart = NAN;
+  double tower_emin = NAN;
+  int light_scint_model = -1;
+  int tower_energy_source = -1;
+
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
+  enum enu_HCalOut_clusterizer
+  {
+    kHCalOutGraphClusterizer,
+    kHCalOutTemplateClusterizer
+  };
+
+  bool useTowerInfoV2 = false;
+
+  //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+  enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutTemplateClusterizer;
+  //! graph clusterizer, RawClusterBuilderGraph
+  // enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutGraphClusterizer;
+}  // namespace G4HCALOUT
+
+// Init is called by G4Setup.C
+void HCalOuterInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4HCALOUT::outer_radius);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4HCALOUT::size_z / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4HCALOUT::size_z / 2.);
+}
+
+double HCalOuter(PHG4Reco *g4Reco,
+                 double radius,
+                 const int crossings)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::HCALOUT_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALOUT_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  PHG4DetectorSubsystem *hcal = nullptr;
+  //  Mephi Maps
+  //  Maps are different for old/new but how to set is identical
+  //  here are the ones for the old outer hcal since the new maps do not exist yet
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALOUT/tilemap/oHCALMaps092021.root");
+  //  hcal->set_string_param("MapHistoName","hCombinedMap");
+
+  if (Enable::HCALOUT_OLD)
+  {
+    hcal = new PHG4OuterHcalSubsystem("HCALOUT");
+    // hcal->set_double_param("inner_radius", 183.3);
+    //-----------------------------------------
+    // the light correction can be set in a single call
+    // hcal->set_double_param("light_balance_inner_corr", NAN);
+    // hcal->set_double_param("light_balance_inner_radius", NAN);
+    // hcal->set_double_param("light_balance_outer_corr", NAN);
+    // hcal->set_double_param("light_balance_outer_radius", NAN);
+    // hcal->set_double_param("magnet_cutout_radius", 195.31);
+    // hcal->set_double_param("magnet_cutout_scinti_radius", 195.96);
+    // hcal->SetLightCorrection(NAN,NAN,NAN,NAN);
+    //-----------------------------------------
+    // hcal->set_double_param("outer_radius", G4HCALOUT::outer_radius);
+    // hcal->set_double_param("place_x", 0.);
+    // hcal->set_double_param("place_y", 0.);
+    // hcal->set_double_param("place_z", 0.);
+    // hcal->set_double_param("rot_x", 0.);
+    // hcal->set_double_param("rot_y", 0.);
+    // hcal->set_double_param("rot_z", 0.);
+    // hcal->set_double_param("scinti_eta_coverage", 1.1);
+    // hcal->set_double_param("scinti_gap", 0.85);
+    // hcal->set_double_param("scinti_gap_neighbor", 0.1);
+    // hcal->set_double_param("scinti_inner_radius",183.89);
+    // hcal->set_double_param("scinti_outer_radius",263.27);
+    // hcal->set_double_param("scinti_tile_thickness", 0.7);
+    // hcal->set_double_param("size_z", G4HCALOUT::size_z);
+    // hcal->set_double_param("steplimits", NAN);
+    // hcal->set_double_param("tilt_angle", -11.23);
+
+    // hcal->set_int_param("light_scint_model", 1);
+    // hcal->set_int_param("magnet_cutout_first_scinti", 8);
+    // hcal->set_int_param("ncross", 0);
+    // hcal->set_int_param("n_towers", 64);
+    // hcal->set_int_param("n_scinti_plates_per_tower", 5);
+    // hcal->set_int_param("n_scinti_tiles", 12);
+
+    // hcal->set_string_param("material", "Steel_1006");
+  }
+  else
+  {
+    hcal = new PHG4OHCalSubsystem("HCALOUT");
+    if (Enable::HCALOUT_RING)
+    {
+      std::string gdmlfile_no_ring =   string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml"; 
+      hcal->set_string_param("GDMPath", gdmlfile_no_ring);
+    }
+    // hcal->set_string_param("GDMPath", "mytestgdml.gdml"); // try other gdml file
+    // common setting with tracking, we likely want to move to the cdb with this
+    hcal->set_string_param("IronFieldMapPath", G4MAGNET::magfield_OHCAL_steel);
+    hcal->set_double_param("IronFieldMapScale", G4MAGNET::magfield_rescale);
+  }
+
+  if (G4HCALOUT::light_scint_model >= 0)
+  {
+    hcal->set_int_param("light_scint_model", G4HCALOUT::light_scint_model);
+  }
+  // hcal->set_int_param("field_check", 1); // for validating the field in HCal
+  hcal->SetActive();
+  hcal->SuperDetector("HCALOUT");
+  if (AbsorberActive)
+  {
+    hcal->SetAbsorberActive();
+  }
+  hcal->OverlapCheck(OverlapCheck);
+  if (!isfinite(G4HCALOUT::phistart))
+  {
+    if (Enable::HCALOUT_OLD)
+    {
+      G4HCALOUT::phistart = 0.026598397;  // offet in phi (from zero) extracted from geantinos
+    }
+    else
+    {
+      G4HCALOUT::phistart = 0.0240615415;  // offet in phi (from zero) extracted from geantinos
+    }
+  }
+  hcal->set_int_param("saveg4hit", Enable::HCALOUT_G4Hit);
+  hcal->set_double_param("phistart", G4HCALOUT::phistart);
+  g4Reco->registerSubsystem(hcal);
+
+  if (!Enable::HCALOUT_OLD)
+  {
+    // HCal support rings, approximated as solid rings
+    // note there is only one ring on either side, but to allow part of the ring inside the HCal envelope two rings are used
+    const double inch = 2.54;
+    const double support_ring_outer_radius = 74.061 * inch;
+    const double innerradius = 56.188 * inch;
+    const double hcal_envelope_radius = 182.423 - 5.;
+    const double support_ring_z = 175.375 * inch / 2.;
+    const double support_ring_dz = 4. * inch;
+    const double z_rings[] =
+        {-support_ring_z, support_ring_z};
+    PHG4CylinderSubsystem *cyl;
+    PHG4CylinderSubsystem *cylout;
+
+    for (int i = 0; i < 2; i++)
+    {
+      // rings outside of HCal envelope
+      cyl = new PHG4CylinderSubsystem("HCAL_SPT_N1", i);
+      cyl->set_double_param("place_z", z_rings[i]);
+      cyl->SuperDetector("HCALIN_SPT");
+      cyl->set_double_param("radius", innerradius);
+      cyl->set_int_param("lengthviarapidity", 0);
+      cyl->set_double_param("length", support_ring_dz);
+      cyl->set_string_param("material", "G4_Al");
+      cyl->set_double_param("thickness", hcal_envelope_radius - 0.1 - innerradius);
+      cyl->set_double_param("start_phi_rad", 1.867);
+      cyl->set_double_param("delta_phi_rad", 5.692);
+      cyl->OverlapCheck(Enable::OVERLAPCHECK);
+      if (AbsorberActive)
+      {
+        cyl->SetActive();
+      }
+      g4Reco->registerSubsystem(cyl);
+
+      // rings inside outer HCal envelope
+      //only use if we want to use the old version of the ring instead of the gdml implementation
+      if (Enable::HCALOUT_RING)
+	{ 
+	  cylout = new PHG4CylinderSubsystem("HCAL_SPT_N1", i + 2);
+	  cylout->set_double_param("place_z", z_rings[i]);
+	  cylout->SuperDetector("HCALIN_SPT");
+	  cylout->set_double_param("radius", hcal_envelope_radius + 0.1);  // add a mm to avoid overlaps
+	  cylout->set_int_param("lengthviarapidity", 0);
+	  cylout->set_double_param("length", support_ring_dz);
+	  cylout->set_string_param("material", "G4_Al");
+	  cylout->set_double_param("thickness", support_ring_outer_radius - (hcal_envelope_radius + 0.1));
+	  cylout->set_double_param("start_phi_rad", 1.867);
+	  cylout->set_double_param("delta_phi_rad", 5.692);
+	  if (AbsorberActive)
+	    {
+	      cylout->SetActive();
+	    }
+	  cylout->SetMotherSubsystem(hcal);
+	  cylout->OverlapCheck(OverlapCheck);
+	  g4Reco->registerSubsystem(cylout);
+	}
+    }
+  }
+
+  radius = hcal->get_double_param("outer_radius");
+
+  radius += no_overlapp;
+
+  return radius;
+}
+
+void HCALOuter_Cells()
+{
+  if (!Enable::HCALOUT_G4Hit) return;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4HcalCellReco *hc = new PHG4HcalCellReco("HCALOUT_CELLRECO");
+  hc->Detector("HCALOUT");
+  hc->Verbosity(verbosity);
+  // check for energy conservation - needs modified "infinite" timing cuts
+  // 0-999999999
+  //  hc->checkenergy();
+  // timing cuts with their default settings
+  // hc->set_double_param("tmin",0.);
+  // hc->set_double_param("tmax",60.0);
+  // or all at once:
+  // hc->set_timing_window(0.0,60.0);
+  // this sets all cells to a fixed energy for debugging
+  // hc->set_fixed_energy(1.);
+  se->registerSubsystem(hc);
+
+  return;
+}
+
+void HCALOuter_Towers()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+  if (Enable::HCALOUT_G4Hit)
+  {
+    HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalOutRawTowerBuilder");
+    TowerBuilder->Detector("HCALOUT");
+    TowerBuilder->set_sim_tower_node_prefix("SIM_NZ");
+    if (!isfinite(G4HCALOUT::phistart))
+    {
+      if (Enable::HCALOUT_OLD)
+      {
+        G4HCALOUT::phistart = 0.026598397;  // offet in phi (from zero) extracted from geantinos
+      }
+      else
+      {
+        G4HCALOUT::phistart = 0.0240615415;  // offet in phi (from zero) extracted from geantinos
+      }
+    }
+    TowerBuilder->set_double_param("phistart", G4HCALOUT::phistart);
+    if (isfinite(G4HCALOUT::tower_emin))
+    {
+      TowerBuilder->set_double_param("emin", G4HCALOUT::tower_emin);
+    }
+    if (G4HCALOUT::tower_energy_source >= 0)
+    {
+      TowerBuilder->set_int_param("tower_energy_source", G4HCALOUT::tower_energy_source);
+    }
+    // this sets specific decalibration factors
+    // for a given cell
+    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+    // for a whole tower
+    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+    TowerBuilder->Verbosity(verbosity);
+    se->registerSubsystem(TowerBuilder);
+  }
+  // From 2016 Test beam sim
+  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
+  TowerDigitizer->Detector("HCALOUT");
+  TowerDigitizer->set_raw_tower_node_prefix("RAW_NZ");
+  TowerDigitizer->set_sim_tower_node_prefix("SIM_NZ");
+  TowerDigitizer->set_digi_algorithm(G4HCALOUT::TowerDigi);
+  TowerDigitizer->set_pedstal_central_ADC(0);
+  TowerDigitizer->set_pedstal_width_ADC(1);  // From Jin's guess. No EMCal High Gain data yet! TODO: update
+  TowerDigitizer->set_photonelec_ADC(16. / 5.);
+  TowerDigitizer->set_photonelec_yield_visible_GeV(16. / 5 / (0.2e-3));
+  TowerDigitizer->set_zero_suppression_ADC(-9999);                  // no-zero suppression
+  TowerDigitizer->Verbosity(verbosity);
+  if (!Enable::HCALOUT_G4Hit) TowerDigitizer->set_towerinfo(RawTowerDigitizer::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  se->registerSubsystem(TowerDigitizer);
+
+  const double visible_sample_fraction_HCALOUT = 3.38021e-02;  // /gpfs/mnt/gpfs04/sphenix/user/jinhuang/prod_analysis/hadron_shower_res_nightly/./G4Hits_sPHENIX_pi-_eta0_16GeV.root_qa.rootQA_Draw_HCALOUT_G4Hit.pdf
+
+  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
+  TowerCalibration->Detector("HCALOUT");
+  TowerCalibration->set_raw_tower_node_prefix("RAW_NZ");
+  TowerCalibration->set_calib_tower_node_prefix("CALIB_NZ");
+  TowerCalibration -> set_usetowerinfo_v2(G4HCALOUT::useTowerInfoV2);
+
+  //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
+  //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
+  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  if (G4HCALOUT::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    // 0.033 extracted from electron sims (edep(scintillator)/edep(total))
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.033);
+  }
+  else
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(0.2e-3 / visible_sample_fraction_HCALOUT);
+  }
+  TowerCalibration->set_pedstal_ADC(0);
+  TowerCalibration->Verbosity(verbosity);
+  if (!Enable::HCALOUT_G4Hit) TowerCalibration->set_towerinfo(RawTowerCalibration::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo
+  se->registerSubsystem(TowerCalibration);
+
+  return;
+}
+
+void HCALOuter_Clusters()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (G4HCALOUT::HCalOut_clusterizer == G4HCALOUT::kHCalOutTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalOutRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("HCALOUT");
+    ClusterBuilder->SetCylindricalGeometry();                      // has to be called after Detector()
+    ClusterBuilder->Verbosity(verbosity);
+    if (!Enable::HCALOUT_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4HCALOUT::HCalOut_clusterizer == G4HCALOUT::kHCalOutGraphClusterizer)
+  {
+    RawClusterBuilderGraph *ClusterBuilder = new RawClusterBuilderGraph("HcalOutRawClusterBuilderGraph");
+    ClusterBuilder->Detector("HCALOUT");
+    ClusterBuilder->Verbosity(verbosity);
+    //if (!Enable::HCALOUT_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "HCALOuter_Clusters - unknown clusterizer setting!" << endl;
+    exit(1);
+  }
+
+  return;
+}
+
+void HCALOuter_Eval(const std::string &outputfile, int start_event = 0)
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("HCALOUTEVALUATOR", "HCALOUT", outputfile);
+  eval->set_event(start_event);
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}
+
+void HCALOuter_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("HCALOUT");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
+#endif

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalOut_ref.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_HcalOut_ref.C
@@ -370,7 +370,9 @@ void HCALOuter_Clusters()
     ClusterBuilder->Detector("HCALOUT");
     ClusterBuilder->SetCylindricalGeometry();                      // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
-    if (!Enable::HCALOUT_G4Hit) ClusterBuilder->set_UseTowerInfo(1);  // just use towerinfo
+    ClusterBuilder->setInputTowerNodeName("TOWERINFO_CALIB_NZ_HCALOUT");
+    ClusterBuilder->setOutputClusterNodeName("CLUSTER_HCALOUT");
+    ClusterBuilder->set_UseTowerInfo(1);
     se->registerSubsystem(ClusterBuilder);
   }
   else if (G4HCALOUT::HCalOut_clusterizer == G4HCALOUT::kHCalOutGraphClusterizer)

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/G4_Production.C
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/G4_Production.C
@@ -1,0 +1,63 @@
+#ifndef MACRO_G4PRODUCTION_C
+#define MACRO_G4PRODUCTION_C
+
+#include <GlobalVariables.C>
+
+// for directory check
+#include <dirent.h>
+#include <sys/types.h>
+
+namespace Enable
+{
+  bool PRODUCTION = false;
+}
+
+namespace PRODUCTION
+{
+  string SaveOutputDir = "./";
+}
+
+void Production_CreateOutputDir()
+{
+  PRODUCTION::SaveOutputDir = DstOut::OutputDir;
+// check if directory already exists, mkdirs can hang up the system if we have gazillions of them
+  DIR *dr;
+  struct dirent *en;
+  dr = opendir(DstOut::OutputDir.c_str());
+  if (dr)
+  {
+    closedir(dr);  // output directory exists - close it and do nothing
+    return;
+  }
+  string mkdircmd = "mkdir -p " + DstOut::OutputDir;
+  gSystem->Exec(mkdircmd.c_str());
+}
+
+void Production_MoveOutput()
+{
+  if (Enable::DSTOUT)
+  {
+    // if run locally it will try to copy output file to itself wiping it out
+    if (PRODUCTION::SaveOutputDir == ".")
+    {
+      return;
+    }
+    string copyscript = "copyscript.pl";
+    ifstream f(copyscript);
+    bool scriptexists = f.good();
+    f.close();
+    string fulloutfile = DstOut::OutputFile;
+    string mvcmd;
+    if (scriptexists)
+    {
+      mvcmd = copyscript + " -outdir " + PRODUCTION::SaveOutputDir + " " + fulloutfile;
+    }
+    else
+    {
+      mvcmd = "mv " + fulloutfile + " " + PRODUCTION::SaveOutputDir;
+    }
+    cout << "mvcmd: " << mvcmd << endl;
+    gSystem->Exec(mvcmd.c_str());
+  }
+}
+#endif

--- a/submit/JS_pp200_signal/pass3calo_all/rundir/run_pass3calo_all_js.sh
+++ b/submit/JS_pp200_signal/pass3calo_all/rundir/run_pass3calo_all_js.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/bash
+export USER="$(id -u -n)"
+export LOGNAME=${USER}
+export HOME=/sphenix/u/${USER}
+
+hostname
+
+this_script=$BASH_SOURCE
+this_script=`readlink -f $this_script`
+this_dir=`dirname $this_script`
+echo rsyncing from $this_dir
+echo running: $this_script $*
+
+anabuild=ana.418
+
+source /cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/opt/sphenix/core/bin/sphenix_setup.sh -n $anabuild
+
+cdbtag=MDC2_$anabuild
+
+if [[ ! -z "$_CONDOR_SCRATCH_DIR" && -d $_CONDOR_SCRATCH_DIR ]]
+then
+    cd $_CONDOR_SCRATCH_DIR
+    rsync -av $this_dir/* .
+    getinputfiles.pl $2
+    if [ $? -ne 0 ]
+    then
+	echo error from getinputfiles.pl $2, exiting
+	exit -1
+    fi
+else
+    echo condor scratch NOT set
+    exit -1
+fi
+# arguments 
+# $1: number of events
+# $2: calo g4hits input file
+# $3: output file
+# $4: output dir
+# $5: run number
+# $6: sequence
+
+echo 'here comes your environment'
+printenv
+echo arg1 \(events\) : $1
+echo arg2 \(calo g4hits file\): $2
+echo arg3 \(output file\): $3
+echo arg4 \(output dir\): $4
+echo arg5 \(runnumber\): $5
+echo arg6 \(sequence\): $6
+echo cdbtag: $cdbtag
+
+runnumber=$(printf "%010d" $5)
+sequence=$(printf "%06d" $6)
+
+filename=timing
+
+echo running root.exe -q -b Fun4All_G4_Calo.C\($1,\"$2\",\"$3\",\"$4\",\"$cdbtag\"\)
+root.exe -q -b  Fun4All_G4_Calo.C\($1,\"$2\",\"$3\",\"$4\",\"$cdbtag\"\)
+
+timedirname=/sphenix/sim/sim01/sphnxpro/mdc2/logs/ampt/pass2calo_nopileup_nozero/timing.run${5}
+
+[ ! -d $timedirname ] && mkdir -p $timedirname
+
+rootfilename=${timedirname}/${filename}-${runnumber}-${sequence}.root
+
+[ -f jobtime.root ] && cp -v jobtime.root $rootfilename
+
+echo "script done"


### PR DESCRIPTION
nodes for EMCal with some notes on how are they made :)
```cpp
    out->AddNode("TOWER_SIM_NZ_CEMC"); //raw tower object, truth energy in scintillator from G4Hits
    out->AddNode("TOWER_RAW_NZ_CEMC");//raw tower object, digitized tower ADC(doesn't match with data scale), without zero suppression. Note: the zero suppression in rawtowerbuilder sets tower below certain energy threshold to 0.
    out->AddNode("TOWER_CALIB_NZ_CEMC");//raw tower object, calibrated tower energy(tower_sim scaled with sampling fraction, with digitization effect)
    out->AddNode("TOWERINFO_RAW_NZ_CEMC");
    out->AddNode("TOWERINFO_SIM_NZ_CEMC");
    out->AddNode("TOWERINFO_CALIB_NZ_CEMC");// same with above but with towerinfo object
    out->AddNode("CLUSTER_CEMC"); //clusters made from TOWERINFO_CALIB_NZ_CEMC
    out->AddNode("WAVEFORM_CEMC"); //TowerInfov3, emulated tower waveforms from G4Hits
    out->AddNode("TOWERS_CEMC"); //TowerInfov2,  WAVEFORM_CEMC processed with CaloTowerBuilder with software zero suppression and template fit
    out->AddNode("TOWERINFO_CALIB_CEMC");// Towerinfov2, calibrated tower energy from TOWERS_CEMC
    out->AddNode("CLUSTERINFO_CEMC");// cluster made from TOWERINFO_CALIB_CEMC
```