### PR TITLE
Herwig embedding id fix

### DIFF
--- a/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
+++ b/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
@@ -85,9 +85,9 @@ int Fun4All_G4_Pass1_herwig(
   // verbosity setting (applies to all input managers)
   Input::VERBOSITY = 1;  // so we get prinouts of the event number
   Input::HEPMC = true;
+  Input::EmbedId = 1;
 
   INPUTHEPMC::filename = inputFile;
-  INPUTHEPMC::_embedding_id = 1;
 
   // Event pile up simulation with collision rate in Hz MB collisions.
   // Enable this is emulating the nominal pp/pA/AA collision vertex distribution

--- a/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
+++ b/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
@@ -87,6 +87,7 @@ int Fun4All_G4_Pass1_herwig(
   Input::HEPMC = true;
 
   INPUTHEPMC::filename = inputFile;
+  INPUTHEPMC::_embedding_id = 1;
 
   // Event pile up simulation with collision rate in Hz MB collisions.
   // Enable this is emulating the nominal pp/pA/AA collision vertex distribution


### PR DESCRIPTION
Set EmbedId to 1 for the HepMC input for Herwig such that the TruthJet will actually be reconstructed