### PR TITLE
updated macro to properly include embedding ID for Herwig HepMC input files

### DIFF
--- a/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
+++ b/submit/Herwig/pass1/rundir/Fun4All_G4_Pass1_herwig.C
@@ -88,6 +88,7 @@ int Fun4All_G4_Pass1_herwig(
   Input::EmbedId = 1;
 
   INPUTHEPMC::filename = inputFile;
+  INPUTHEPMC::EmbedId = 1;
 
   // Event pile up simulation with collision rate in Hz MB collisions.
   // Enable this is emulating the nominal pp/pA/AA collision vertex distribution


### PR DESCRIPTION
Does what is says on the tin. Added a line to the pass 1 macro to set the embedding ID correctly in InputHEPMC 
